### PR TITLE
no scanner

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,8 +50,6 @@
 	<string>Gomart uses a feature that requires user to capture photo with his camera and upload it</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Gomart uses has features that require user to upload his photo or a product photo</string>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Gomart uses location when app is in use and when we need to use your location to suggest nearby products & Services</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
@@ -77,5 +75,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+    <string>This app needs access to location when open.</string>
+    <key>NSLocationAlwaysUsageDescription</key>
+    <string>This app needs access to location when in the background.</string>
 </dict>
 </plist>


### PR DESCRIPTION
- removed qr mobile scanner completely
- upgraded xcode version
- removed user in Edit business and businessProfile page, cause it seemed redundant and looks better now, and then tweaked the textfields
- adjusted some fonts here and there
- worked a bit on the styling of add product page
- modified the account page  a bit
- we are now able to pick logo and banner photo from gallary
- text fields are now active and we can now pick multiple items for our gallery
- testing picking up one image and multiple images since it works on emulator and doesn't work on the phone
- testing picking up one image and multiple images since it works on emulator and doesn't work on the phone
- fixed adding galery store photos from multi to single
- fixed google prediction issue and also fixed add store gallary photos issues, turns out It was only working in debug mode
- refactored some components of edit business, and also added get current location, will be testing it now
- info .plist had issues, so I tried to fix it, hope it got fixed
