### PR TITLE
no scanner

### DIFF
--- a/lib/screens/Home/Screens/Account/EditBusiness/_address_auto_complete.dart
+++ b/lib/screens/Home/Screens/Account/EditBusiness/_address_auto_complete.dart
@@ -48,7 +48,14 @@ class EnterAddressAutoCompleteState extends State<EnterAddressAutoComplete> {
             child: TextField(
               controller: _textController,
               decoration: const InputDecoration(
+                  enabledBorder: OutlineInputBorder(
+                      borderSide: BorderSide(
+                          color: Styles.colorTextFieldBorder, width: 0.8
+                      )),
                   focusColor: Styles.colorGray,
+                  focusedBorder:  OutlineInputBorder(
+                    borderSide: BorderSide(color: Styles.colorPrimary,  width: 0.8,),
+                  ),
                   contentPadding:
                       EdgeInsets.symmetric(vertical: 0, horizontal: 8),
                   border: OutlineInputBorder(

--- a/lib/screens/Home/Screens/Account/EditBusiness/_text_field.dart
+++ b/lib/screens/Home/Screens/Account/EditBusiness/_text_field.dart
@@ -11,10 +11,16 @@ class GomTextField extends StatefulWidget {
   final bool isMoney;
   final bool isCompact;
   final TextInputType? keyboardType;
+
   const GomTextField({
     super.key,
     this.onChanged,
-    this.initialValue = '', this.leadingIcon,  this.isTextArea = false, this.keyboardType, this.isMoney = false, this.isCompact = false  ,
+    this.initialValue = '',
+    this.leadingIcon,
+    this.isTextArea = false,
+    this.keyboardType,
+    this.isMoney = false,
+    this.isCompact = false,
   });
 
   @override
@@ -33,22 +39,31 @@ class _GomTextFieldState extends State<GomTextField> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: widget.isTextArea? 100:32,
+      height: widget.isTextArea ? 100 : 32,
       child: TextField(
-        style: widget.isCompact? const TextStyle(
-          fontSize: 14
-        ):null,
-          inputFormatters:widget.isMoney? [MoneyInputFormatter()]:null,
-        keyboardType: widget.keyboardType,
+          style: widget.isCompact ? const TextStyle(fontSize: 14) : null,
+          inputFormatters: widget.isMoney ? [MoneyInputFormatter()] : null,
+          keyboardType: widget.keyboardType,
           controller: _textEditingController,
-          maxLines:widget.isTextArea? 6:null,
+          maxLines: widget.isTextArea ? 6 : null,
           decoration: InputDecoration(
               prefixIcon: widget.leadingIcon,
-              focusColor: Styles.colorGray,
-              contentPadding:  EdgeInsets.symmetric(vertical: widget.isTextArea?8: widget.isCompact?2: 0, horizontal: 8),
+         enabledBorder:  OutlineInputBorder(
+           borderSide: BorderSide(color: Styles.colorTextFieldBorder,  width: 0.8,),
+         ),
+              focusedBorder:  OutlineInputBorder(
+           borderSide: BorderSide(color: Styles.colorPrimary,  width: 0.8,),
+         ),
+              contentPadding: EdgeInsets.symmetric(
+                  vertical: widget.isTextArea
+                      ? 8
+                      : widget.isCompact
+                          ? 2
+                          : 0,
+                  horizontal: 8),
               border: const OutlineInputBorder(
                   borderSide: BorderSide(
-                    color: Styles.colorTextFieldBorder,
+                    color: Colors.white,
                     width: 0.8,
                     style: BorderStyle.solid,
                   ),

--- a/lib/screens/Home/Screens/Account/EditBusiness/edit_business_screen.dart
+++ b/lib/screens/Home/Screens/Account/EditBusiness/edit_business_screen.dart
@@ -226,9 +226,19 @@ class LogoAndFieldsSection extends StatelessWidget {
                         child: DropdownButtonFormField(
                             value: state.openingTime,
                             decoration: InputDecoration(
+                              focusedBorder:  OutlineInputBorder(
+                                borderSide: BorderSide(color: Styles.colorPrimary,  width: 0.8,),
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                  borderSide: BorderSide(
+                                      color: Styles.colorTextFieldBorder, width: 0.8
+                                  )),
                               contentPadding: const EdgeInsets.symmetric(
                                   vertical: 0, horizontal: 6),
                               border: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Styles.colorTextFieldBorder, width: 0.8
+                                ),
                                 borderRadius: BorderRadius.circular(5.0),
                               ),
                             ),
@@ -262,6 +272,13 @@ class LogoAndFieldsSection extends StatelessWidget {
                         child: DropdownButtonFormField(
                             value: state.closingTime,
                             decoration: InputDecoration(
+                              enabledBorder: OutlineInputBorder(
+                                  borderSide: BorderSide(
+                                      color: Styles.colorTextFieldBorder, width: 0.8
+                                  )),
+                              focusedBorder:  OutlineInputBorder(
+                                borderSide: BorderSide(color: Styles.colorPrimary,  width: 0.8,),
+                              ),
                               contentPadding: const EdgeInsets.symmetric(
                                   vertical: 0, horizontal: 6),
                               border: OutlineInputBorder(
@@ -310,6 +327,13 @@ class LogoAndFieldsSection extends StatelessWidget {
                           value: state.daysOpen,
                           isExpanded: true,
                           decoration: InputDecoration(
+                            enabledBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                    color: Styles.colorTextFieldBorder, width: 0.8
+                                )),
+                            focusedBorder:  OutlineInputBorder(
+                              borderSide: BorderSide(color: Styles.colorPrimary,  width: 0.8,),
+                            ),
                             contentPadding: const EdgeInsets.symmetric(
                                 vertical: 0, horizontal: 6),
                             border: OutlineInputBorder(

--- a/lib/screens/Home/Screens/Account/ManageProduct/manage_product_screen.dart
+++ b/lib/screens/Home/Screens/Account/ManageProduct/manage_product_screen.dart
@@ -389,7 +389,7 @@ class PaymentMethodSelect extends StatelessWidget {
         ),
         PopupMenuItem(
           value: 'h',
-          child: Container(
+          child: SizedBox(
             width: MediaQuery.of(context).size.width,
             child: Row(
               mainAxisAlignment: MainAxisAlignment.start,
@@ -399,8 +399,8 @@ class PaymentMethodSelect extends StatelessWidget {
                     height: 30,
                 width: 35,),
                 const Padding(padding: EdgeInsets.all(4)),
-                Padding(
-                  padding: const EdgeInsets.all(6.0),
+                const Padding(
+                  padding: EdgeInsets.all(6.0),
                   child: Text('Add debit/credit card',
                     style: TextStyle(
                       fontSize:16,

--- a/lib/styles/styles.dart
+++ b/lib/styles/styles.dart
@@ -20,7 +20,7 @@ abstract class Styles {
   static const Color colorTextFieldBackground = Color(0xffF1F1F1);
   static const Color colorTextFieldHint = Color(0xff8A8686);
   static const Color colorGray = Color(0xff8A8686);
-  static const Color colorTextFieldBorder = Color(0xffAEAEAE);
+  static const Color colorTextFieldBorder = Color(0xffdbdbdb);
 
   static const Color colorTextGomartText = Color(0xff606060);
   static const Color colorSkeletalBackground= Color(0xfffafafa);


### PR DESCRIPTION
- removed qr mobile scanner completely
- upgraded xcode version
- removed user in Edit business and businessProfile page, cause it seemed redundant and looks better now, and then tweaked the textfields
- adjusted some fonts here and there
- worked a bit on the styling of add product page
- modified the account page  a bit
- we are now able to pick logo and banner photo from gallary
- text fields are now active and we can now pick multiple items for our gallery
- testing picking up one image and multiple images since it works on emulator and doesn't work on the phone
- testing picking up one image and multiple images since it works on emulator and doesn't work on the phone
- fixed adding galery store photos from multi to single
- fixed google prediction issue and also fixed add store gallary photos issues, turns out It was only working in debug mode
- refactored some components of edit business, and also added get current location, will be testing it now
- info .plist had issues, so I tried to fix it, hope it got fixed
- worked on use current location as my address, it is working perfectly now
- refactored some more and then also started persisting textfields in our state
- everything now retains the value from state, in the edit business screen. I also added some tests
- fixed tests
- flutter build android doesn't need to run tests now
- we can now upload real photos and then added a loader when saving, looks good
- fixed our loader
- our repository now does everything we need, we can now proceed to reading the data
- when a person has created a business, account page will change completely
- changed home gomart logo and also added loading screen for profile screen
- changed future builder to stream builder in the profile screen and also pop when saving is complete in edit business screen
- worked on product and business screens, made some progress, and did some nice optimizations and refactorings
- worked mainly on specifications, things looks good and so far so good
- worked on specifications some more
- worked on promote ads section, we now have intact state, working on the admin helped speed things up and also thanks to ChatGPT
- change color of featured
- added additional controls in the manage product page
- remove the text boldness in "Choose from template" section
- added button scrollable sheet for checking out product and then also added a pop-up menu for selecting cards and other payment methods
- changed textField theme, color, to be more subtle
